### PR TITLE
Provide a more helpful error on pip install.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,24 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
+# The install_requires does not support installation from git.
+try:
+    import databroker_fitshandler
+except ImportError:
+    print(
+        "\n"
+        "\n"
+        "You must manually install databroker_fitshandler:\n"
+        "pip install git+git://github.com/als-computing/datahandler_fits@master#egg=databroker-fitshandler"
+        "\n"
+        "\n"
+    )
+    import sys
+    sys.exit(1)
 with open(path.join(here, 'requirements.txt')) as requirements_file:
     # Parse requirements.txt, ignoring any commented-out lines.
     requirements = [line for line in requirements_file.read().splitlines()
-                    if not line.startswith('#')]
+                    if not (line.startswith('#') or line.startswith("git+"))]
 setup(
 
     name='splash-server',  


### PR DESCRIPTION
A somewhat silly first PR, but it might help someone.

I like and always use the pattern of parsing `requirements.txt` to populate the `install_requires` parameter in `setup.py`. But an annoying restriction to keep in mind is that while

```
pip install -r requirements.txt
```

works with `git+https://...` specifications, `install_requires` only accepts proper packages on a packaging index (e.g. PyPI). There is not a good workaround for this as far as I know. All you can do is provide a more helpful error message.

Before:

```sh
$ pip install -e .
Obtaining file:///home/dallan/Repos/bnl/splash-server
    ERROR: Command errored out with exit status 1:
     command: /home/dallan/miniconda3/envs/py38/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/dallan/Repos/bnl/splash-server/setup.py'"'"'; __file__='"'"'/home/dallan/Repos/bnl/splash-server/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-pxhdmmpn
         cwd: /home/dallan/Repos/bnl/splash-server/
    Complete output (1 lines):
    error in splash-server setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Parse error at "'+https:/'": Expected stringEnd
    ----------------------------------------
```

After:

```
$ pip install -e .
Obtaining file:///home/dallan/Repos/bnl/splash-server
    ERROR: Command errored out with exit status 1:
     command: /home/dallan/miniconda3/envs/py38/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/dallan/Repos/bnl/splash-server/setup.py'"'"'; __file__='"'"'/home/dallan/Repos/bnl/splash-server/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-y7mgc4v3
         cwd: /home/dallan/Repos/bnl/splash-server/
    Complete output (6 lines):
    
    
    You must manually install databroker_fitshandler:
    pip install git+git://github.com/als-computing/datahandler_fits@master#egg=databroker-fitshandler
    
    
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```