### PR TITLE
User security changes and validation changes

### DIFF
--- a/splash/service/authorization.py
+++ b/splash/service/authorization.py
@@ -27,3 +27,16 @@ class TeamBasedChecker(Checker):
 
     def can_do(self, user: User, resource, action: Action, teams=List[Team], **kwargs):
         raise NotImplementedError
+
+
+class NotAuthorized(Exception):
+    pass
+
+
+# decorator for checking admin status of a user
+def authorize_admin_action(func):
+    def wrapper(self, current_user: User, *args, **kwargs):
+        if current_user.splash_md.admin is True:
+            return func(self, current_user, *args, **kwargs)
+        raise NotAuthorized('user is not an admin')
+    return wrapper

--- a/splash/service/base.py
+++ b/splash/service/base.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 import logging
-from splash.service.models import SplashMetadata
+from splash.service.models import SplashMetadata, VersionedSplashMetadata
 import uuid
 from datetime import datetime
 from splash.users import User
@@ -12,6 +12,51 @@ from pymongo import ASCENDING
 ValidationIssue = namedtuple("ValidationIssue", "description, location, exception")
 
 logger = logging.getLogger("splash.service")
+
+
+# This is a decorator which ensures that none of fields in SplashMetadata 
+# Are being modified. We only want these fields to be modified by MongoService
+# It also ensures that the uid is not being modified
+def validate_base_metadata(func):
+    def wrapper(self, current_user: User, data: dict, *args, **kwargs):
+        if "uid" in data:
+            raise UidInDictError("Document should not have uid field")
+
+        if "splash_md" not in data:
+            return func(self, current_user, data, *args, **kwargs)
+
+        basic_md_fields = SplashMetadata.__dict__["__fields__"]
+        # The top layer that called this cannot mutate
+        # any of these fields. They should only be mutated by
+        # this service layer
+        for field in basic_md_fields:
+            if field in data["splash_md"]:
+                raise ImmutableMetadataField(
+                    f"Cannot mutate field: `{field}` in `splash_md`"
+                )
+        return func(self, current_user, data, *args, **kwargs)
+    return wrapper
+
+
+# This is a decorator which ensures that none of the fields in VersionedSplashMetadata
+# are being modified.
+def validate_versioned_metadata(func):
+    def wrapper(self, current_user: User, data: dict, *args, **kwargs):
+
+        if "splash_md" not in data:
+            return func(self, current_user, data, *args, **kwargs)
+
+        versioned_md_fields = VersionedSplashMetadata.__dict__["__fields__"]
+        # The top layer that called this cannot mutate
+        # any of these fields. They should only be mutated by
+        # this service layer
+        for field in versioned_md_fields:
+            if field in data["splash_md"]:
+                raise ImmutableMetadataField(
+                    f"Cannot mutate field: `{field}` in `splash_md`"
+                )
+        return func(self, current_user, data, *args, **kwargs)
+    return wrapper
 
 
 class BadPageArgument(Exception):
@@ -49,21 +94,14 @@ class MongoService:
         sort_index = IndexModel([("splash_md.last_edit", DESCENDING), ("uid", DESCENDING)])
         self._collection.create_indexes([uid_unique_index, creator_index, sort_index])
 
+    @validate_base_metadata
     def create(self, current_user: User, data: dict):
-        if "uid" in data:
-            raise UidInDictError("Document should not have uid field")
         uid = uuid.uuid4()
         data["uid"] = str(uid)
 
         if "splash_md" not in data:
             data["splash_md"] = {}
 
-        basic_md_fields = SplashMetadata.__dict__["__fields__"]
-        for field in basic_md_fields:
-            if field in data["splash_md"]:
-                raise ImmutableMetadataField(
-                    f"Cannot mutate field: `{field}` in `splash_md`"
-                )
         # remove the microsecond because mongo will truncate past a certain amount of decimal places
         data["splash_md"]["create_date"] = datetime.utcnow().replace(microsecond=0)
         data["splash_md"]["last_edit"] = data["splash_md"]["create_date"]
@@ -111,6 +149,7 @@ class MongoService:
             cursor.sort(sort).collation(Collation("en_US")).skip(skips).limit(page_size)
         )
 
+    @validate_base_metadata
     def update(self, current_user: User, data: dict, uid: str, etag=None):
         data["uid"] = uid
 
@@ -131,16 +170,8 @@ class MongoService:
             # If the top layer is also sending in metadata
             # then we want to merge it with the metadata already in the
             # document
-            basic_md_fields = SplashMetadata.__dict__["__fields__"]
-            for field in basic_md_fields:
-                # The top layer that called this cannot mutate
-                # any of these fields. They should only be mutated by
-                # this service layer
-                if field in data["splash_md"]:
-                    raise ImmutableMetadataField(
-                        f"Cannot mutate field: `{field}` in `splash_md`"
-                    )
-                data["splash_md"][field] = metadata[field]
+            metadata.update(data["splash_md"])
+            data["splash_md"] = metadata
         # Update the edit_record array and last edit timestamp
         # remove the microsecond because mongo will truncate past a certain amount of decimal places
         data["splash_md"]["last_edit"] = datetime.utcnow().replace(microsecond=0)
@@ -176,15 +207,10 @@ class VersionedMongoService(MongoService):
         super().__init__(db, collection_name)
         self._versions_svc = HistoricMongoService(db, revisions_collection_name)
 
+    @validate_versioned_metadata
     def update(self, current_user: User, data: dict, uid: str, etag=None):
-        if "splash_md" in data:
-            if "version" in data["splash_md"]:
-                raise ImmutableMetadataField(
-                    "Cannot mutate field: `version` in `splash_md`"
-                )
-        else:
+        if "splash_md" not in data:
             data["splash_md"] = {}
-
         current_document = super().retrieve_one(current_user, uid)
         if current_document is None:
             raise ObjectNotFoundError
@@ -193,13 +219,9 @@ class VersionedMongoService(MongoService):
         self._versions_svc._collection.insert_one(current_document)
         return result
 
+    @validate_versioned_metadata
     def create(self, current_user: User, data: dict):
-        if "splash_md" in data:
-            if "version" in data["splash_md"]:
-                raise ImmutableMetadataField(
-                    "Cannot mutate field: `version` in `splash_md`"
-                )
-        else:
+        if "splash_md" not in data:
             data["splash_md"] = {}
         data["splash_md"]["version"] = 1
         return super().create(current_user, data)

--- a/splash/test/conftest.py
+++ b/splash/test/conftest.py
@@ -7,4 +7,5 @@ from .fixtures.add import (
     teams_service,
     mock_collation_prop,
     test_user1,
+    # fresh_mongodb,
 )

--- a/splash/test/fixtures/add.py
+++ b/splash/test/fixtures/add.py
@@ -9,7 +9,7 @@ from splash.pages.pages_routes import set_pages_service
 from splash.pages.pages_service import PagesService
 from splash.references.references_routes import set_references_service
 from splash.references.references_service import ReferencesService
-from splash.users import NewUser
+from splash.users import NewUser, User
 from splash.users.users_routes import set_users_service
 from splash.users.users_service import UsersService
 from splash.runs.runs_routes import set_runs_service
@@ -55,11 +55,15 @@ def mock_collation_prop(monkeypatch):
 def mongodb():
     return db
 
+# @pytest.fixture
+# def fresh_mongodb():
+#     return mongomock.MongoClient().db
+
 
 @pytest.fixture
 def test_user1():
     return NewUser(
-        given_name="ford", family_name="prefect", email="ford@beetleguice.planet"
+        given_name="ford", family_name="prefect", email="ford@beetleguice.planet", 
     )
 
 
@@ -73,10 +77,33 @@ def test_user1():
 token_info1 = {"sub": None, "scopes": ["splash"]}
 token_info2 = {"sub": None, "scopes": ["splash"]}
 
+admin_user1 = User(
+        splash_md={
+            "creator": "NONE",
+            "create_date": "2020-01-7T13:40:53",
+            "last_edit": "2020-01-7T13:40:53",
+            "edit_record": [],
+            "etag": "f672367e-c534-4f4a-9e5a-0941dbab2d1c",
+            "admin": True
+        },
+        uid="foobar1",
+        given_name="Sauron",
+        family_name="The Dark Lord",
+        email="Sauron@mordor.net",
+    )
+
+admin_user2 = NewUser(
+        splash_md={
+            "admin": True
+        },
+        given_name="Melkor",
+        family_name="The Ainur",
+        email="Melkor@silmarillion.com",
+    )
 
 @pytest.fixture
 def splash_client(mongodb, test_user1, monkeypatch):
-    uid = users_svc.create(None, test_user1)["uid"]
+    uid = users_svc.create(admin_user1, admin_user2)["uid"]
     token_info1["sub"] = uid
     client = TestClient(app)
     return client
@@ -129,13 +156,13 @@ other_team = {
 
 @pytest.fixture(scope="session", autouse=True)
 def users():
-    user_leader_uid = users_svc.create(None, NewUser(**leader))["uid"]
-    user_same_team_uid = users_svc.create(None, NewUser(**same_team))["uid"]
-    user_other_team_uid = users_svc.create(None, NewUser(**other_team))["uid"]
+    user_leader_uid = users_svc.create(admin_user1, NewUser(**leader))["uid"]
+    user_same_team_uid = users_svc.create(admin_user1, NewUser(**same_team))["uid"]
+    user_other_team_uid = users_svc.create(admin_user1, NewUser(**other_team))["uid"]
     users = {}
-    users["leader"] = users_svc.retrieve_one(None, user_leader_uid)
-    users["same_team"] = users_svc.retrieve_one(None, user_same_team_uid)
-    users["other_team"] = users_svc.retrieve_one(None, user_other_team_uid)
+    users["leader"] = users_svc.retrieve_one(admin_user1, user_leader_uid)
+    users["same_team"] = users_svc.retrieve_one(admin_user1, user_same_team_uid)
+    users["other_team"] = users_svc.retrieve_one(admin_user1, user_other_team_uid)
     return users
 
 

--- a/splash/test/test_mongo_service.py
+++ b/splash/test/test_mongo_service.py
@@ -235,13 +235,18 @@ def test_create_with_bad_metadata(mongo_service: MongoService, request_user_1: U
 def test_update_with_good_metadata(mongo_service: MongoService, request_user_1: User):
     response = mongo_service.create(request_user_1, {"Mordor": "Mt. Doom"})
 
-    data = mongo_service.retrieve_one(request_user_1, response["uid"])
-    data.pop("splash_md")
-    data["splash_md"] = {"muteable_field": "test"}
-    data.pop("uid")
+    incoming_data = mongo_service.retrieve_one(request_user_1, response["uid"])
+    incoming_data.pop("splash_md")
+    incoming_data["splash_md"] = {"muteable_field": "test"}
+    incoming_data.pop("uid")
 
-    mongo_service.update(request_user_1, data, response["uid"])
-    assert data == mongo_service.retrieve_one(request_user_1, response["uid"])
+    mongo_service.update(request_user_1, deepcopy(incoming_data), response["uid"])
+
+    stored_data = mongo_service.retrieve_one(request_user_1, response["uid"])
+    # Make sure body stayed the same
+    equal_dicts(incoming_data, stored_data, ignore_keys)
+    # Make sure that the field was changed
+    assert incoming_data["splash_md"]["muteable_field"] == stored_data["splash_md"]["muteable_field"]
 
 
 def test_update_with_bad_metadata(mongo_service: MongoService, request_user_1: User):

--- a/splash/test/test_mongo_service.py
+++ b/splash/test/test_mongo_service.py
@@ -232,6 +232,18 @@ def test_create_with_bad_metadata(mongo_service: MongoService, request_user_1: U
             mongo_service.create(request_user_1, {"splash_md": {field: "test_value"}})
 
 
+def test_update_with_good_metadata(mongo_service: MongoService, request_user_1: User):
+    response = mongo_service.create(request_user_1, {"Mordor": "Mt. Doom"})
+
+    data = mongo_service.retrieve_one(request_user_1, response["uid"])
+    data.pop("splash_md")
+    data["splash_md"] = {"muteable_field": "test"}
+    data.pop("uid")
+
+    mongo_service.update(request_user_1, data, response["uid"])
+    assert data == mongo_service.retrieve_one(request_user_1, response["uid"])
+
+
 def test_update_with_bad_metadata(mongo_service: MongoService, request_user_1: User):
     response = mongo_service.create(request_user_1, {"Mordor": "Mt. Doom"})
 

--- a/splash/test/test_users_service.py
+++ b/splash/test/test_users_service.py
@@ -1,0 +1,122 @@
+import pytest
+from splash.users.users_service import UsersService
+from splash.service.authorization import NotAuthorized
+from splash.users import User, NewUser
+from mongomock import MongoClient
+from .testing_utils import equal_dicts
+
+
+@pytest.fixture
+def admin_user():
+    return User(
+        splash_md={
+            "creator": "NONE",
+            "create_date": "2020-01-7T13:40:53",
+            "last_edit": "2020-01-7T13:40:53",
+            "edit_record": [],
+            "etag": "f672367e-c534-4f4a-9e5a-0941dbab2d1c",
+            "admin": True
+        },
+        uid="foobar1",
+        given_name="Sauron",
+        family_name="The Dark Lord",
+        email="Sauron@mordor.net",
+    )
+
+
+@pytest.fixture
+def regular_user():
+    return User(
+        splash_md={
+            "creator": "NONE",
+            "create_date": "2020-01-7T13:40:53",
+            "last_edit": "2020-01-7T13:40:53",
+            "edit_record": [],
+            "etag": "f672367e-c534-4f4a-9e5a-0941dbab2d1c",
+            "admin": False
+        },
+        uid="foobar2",
+        given_name="Saruman",
+        family_name="The White",
+        email="saruman@middleearth.org",
+    )
+
+@pytest.fixture
+def regular_user_no_admin_prop():
+    return User(
+        splash_md={
+            "creator": "NONE",
+            "create_date": "2020-01-7T13:40:53",
+            "last_edit": "2020-01-7T13:40:53",
+            "edit_record": [],
+            "etag": "f672367e-c534-4f4a-9e5a-0941dbab2d1c",
+        },
+        uid="foobar3",
+        given_name="Gandalf",
+        family_name="The Grey",
+        email="Gandalf@middleearth.org",
+    )
+
+db = MongoClient().db
+
+
+@pytest.fixture
+def users_service():
+    users_service = UsersService(db, "users")
+    return users_service
+
+
+uid = ""
+
+
+def test_admin_can_create_and_edit(users_service: UsersService, admin_user):
+    uruk_user = NewUser(given_name="Uruk", family_name="Hai", email="uruk@mordor.net")
+    resp = users_service.create(admin_user, uruk_user)
+    uid = resp["uid"]
+    document = users_service.retrieve_one(admin_user, uid).dict()
+
+    uruk_dict = uruk_user.dict()
+
+    assert uruk_dict['given_name'] == document['given_name']
+    assert uruk_dict['family_name'] == document['family_name']
+    assert uruk_dict['email'] == document['email']
+
+    update = NewUser(given_name="Uruk", family_name="Hai", email="uruk@middleearth.org")
+    resp = users_service.update(admin_user, update, uid)
+    document = users_service.retrieve_one(admin_user, uid).dict()
+
+    update_dict = update.dict()
+
+    assert update_dict['given_name'] == document['given_name']
+    assert update_dict['family_name'] == document['family_name']
+    assert update_dict['email'] == document['email']
+
+    return
+
+
+def test_regular_cannot_edit(users_service: UsersService, regular_user):
+    uruk_user = NewUser(given_name="Uruk", family_name="Hai", email="uruk@mordor.net")
+    with pytest.raises(NotAuthorized, match="user is not an admin"):
+        users_service.create(regular_user, uruk_user)
+
+    with pytest.raises(NotAuthorized, match="user is not an admin"):
+        users_service.update(regular_user, uruk_user, uid)
+
+    with pytest.raises(NotAuthorized, match="user is not an admin"):
+        users_service.delete(regular_user, uid)
+
+    return
+
+
+def test_regular_no_admin_prop_cannot_edit(users_service: UsersService, regular_user_no_admin_prop):
+    uruk_user = NewUser(given_name="Uruk", family_name="Hai", email="uruk@mordor.net")
+    with pytest.raises(NotAuthorized, match="user is not an admin"):
+        users_service.create(regular_user_no_admin_prop, uruk_user)
+
+    with pytest.raises(NotAuthorized, match="user is not an admin"):
+        users_service.update(regular_user_no_admin_prop, uruk_user, uid)
+
+    with pytest.raises(NotAuthorized, match="user is not an admin"):
+        users_service.delete(regular_user_no_admin_prop, uid)
+
+    return

--- a/splash/test/test_versioned_service.py
+++ b/splash/test/test_versioned_service.py
@@ -48,13 +48,14 @@ def test_versioned_update(versioned_service: VersionedMongoService, request_user
         )
 
     response = versioned_service.create(
-        request_user, {"name": "Celebrimbor", "Occupation": "Ringmaker"}
+        request_user, {"splash_md": {"test": "test"}, "name": "Celebrimbor", "Occupation": "Ringmaker"}
     )
     uid = response["uid"]
 
     document_1 = versioned_service.retrieve_one(request_user, uid)
     assert document_1["uid"] == uid
     assert document_1["splash_md"]["version"] == 1
+    assert document_1["splash_md"]["test"] == "test"
     assert document_1["name"] == "Celebrimbor"
     assert document_1["Occupation"] == "Ringmaker"
     assert document_1["splash_md"] == response["splash_md"]

--- a/splash/test/testing_utils.py
+++ b/splash/test/testing_utils.py
@@ -50,7 +50,7 @@ def generic_test_api_crud(sample_new_object, url_path, splash_client, token_head
         response.status_code == 200
     ), f"{response.status_code}: response is {response.content}"
 
-    assert post_resp.json()["splash_md"] == response.json()["splash_md"]
+    assert post_resp.json()["splash_md"] == response.json()["splash_md"], f'{post_resp.json()["splash_md"]} is not {response.json()["splash_md"]}'
     # TODO: TEST put api
 
     # response = splash_client.put(url_path + '/' + new_uid, data=json.dumps(sample_new_object), headers=token_header)

--- a/splash/users/__init__.py
+++ b/splash/users/__init__.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 from pydantic import BaseModel, Extra
-from splash.service.models import CreatedDocument
+from splash.service.models import CreatedDocument, SplashMetadata
 
 
 class AuthenticatorModel(BaseModel):
@@ -10,8 +10,15 @@ class AuthenticatorModel(BaseModel):
     subject: Optional[str] #TODO this should be required, but data needs migration
 
 
-class NewUser(BaseModel):
+class NewUserSplashMd(BaseModel):
+    admin: Optional[bool] = None
 
+    class Config:
+        extra = Extra.forbid
+
+
+class NewUser(BaseModel):
+    splash_md: Optional[NewUserSplashMd] = NewUserSplashMd()
     given_name: str
     family_name: str
     email: Optional[str]
@@ -21,5 +28,10 @@ class NewUser(BaseModel):
         extra = Extra.forbid
 
 
+class UserSplashMd(SplashMetadata):
+    admin: Optional[bool] = None
+
+
 class User(NewUser, CreatedDocument):
     disabled: Optional[bool] = None
+    splash_md: UserSplashMd

--- a/splash/users/users_routes.py
+++ b/splash/users/users_routes.py
@@ -1,5 +1,4 @@
 from fastapi.param_functions import Header
-from splash.service.models import SplashMetadata
 from attr import dataclass
 from fastapi import APIRouter, Security
 from fastapi.exceptions import HTTPException
@@ -7,7 +6,7 @@ from fastapi.exceptions import HTTPException
 from pydantic import BaseModel
 from typing import List, Optional
 
-from . import User, NewUser
+from . import User, NewUser, UserSplashMd
 from .users_service import UsersService
 
 from splash.api.auth import get_current_user
@@ -29,7 +28,7 @@ def set_users_service(users_service: UsersService):
 
 class CreateUserResponse(BaseModel):
     uid: str
-    splash_md: SplashMetadata
+    splash_md: UserSplashMd
 
 
 @users_router.get("", tags=["users"], response_model=List[User])

--- a/splash/users/users_service.py
+++ b/splash/users/users_service.py
@@ -2,6 +2,7 @@ from pymongo import ASCENDING, DESCENDING, TEXT
 from pymongo.operations import IndexModel
 from ..users import NewUser, User
 from ..service.base import MongoService
+from ..service.authorization import authorize_admin_action
 
 
 class MultipleUsersAuthenticatorException(Exception):
@@ -24,7 +25,8 @@ class UsersService(MongoService):
         self._collection.create_indexes([text_index, sort_index])
         super()._create_indexes()
 
-    def create(self, current_user: User, new_user: NewUser) -> str:
+    @authorize_admin_action
+    def create(self, current_user: User, new_user: NewUser) -> dict:
         return super().create(current_user, new_user.dict())
 
     def retrieve_one(self, current_user: User, uid: str) -> User:
@@ -45,9 +47,11 @@ class UsersService(MongoService):
         for user_dict in cursor:
             yield User(**user_dict)
 
+    @authorize_admin_action
     def update(self, current_user: User, new_user: NewUser, uid: str, etag: str = None):
         return super().update(current_user, new_user.dict(), uid, etag=etag)
 
+    @authorize_admin_action
     def delete(self, current_user: User, uid):
         raise NotImplementedError
 


### PR DESCRIPTION
This PR makes it so that only users with the `admin` prop in `splash_md` set to true can edit other users. It also makes the validation of `splash_md` by the base services more elegant through using decorators.

fixes #102 