### PR TITLE
Custom references

### DIFF
--- a/scripts/upgrade_v01.9.py
+++ b/scripts/upgrade_v01.9.py
@@ -1,8 +1,6 @@
-# This script attempts to create a partial index on the references collection.
-# If we cannot do this it will throw an error, letting the user know of that so that they can fix it manually
-
 import os
 import pymongo
+from pymongo.collation import Collation
 from pymongo.operations import IndexModel
 
 mongo_uri = os.getenv("MONGO_DB_URI")
@@ -10,13 +8,13 @@ print(f"using {mongo_uri}")
 
 db = pymongo.MongoClient(mongo_uri).get_database()
 
-doi_index_to_be_dropped = IndexModel("DOI")
-
 doi_index = IndexModel(
-            "DOI", partialFilterExpression={"DOI": {"$type": "string"}}, unique=True
-        )
-references = db['references']
+    [("splash_md.archived", pymongo.ASCENDING), ("DOI", pymongo.ASCENDING)],
+    collation=Collation("en_US", strength=2),
+)
 
-references.drop_index([('DOI', 1)])
+
+references = db["references"]
+
+references.drop_index([("DOI", 1)])
 references.create_indexes([doi_index])
-

--- a/scripts/upgrade_v01.9.py
+++ b/scripts/upgrade_v01.9.py
@@ -1,0 +1,22 @@
+# This script attempts to create a partial index on the references collection.
+# If we cannot do this it will throw an error, letting the user know of that so that they can fix it manually
+
+import os
+import pymongo
+from pymongo.operations import IndexModel
+
+mongo_uri = os.getenv("MONGO_DB_URI")
+print(f"using {mongo_uri}")
+
+db = pymongo.MongoClient(mongo_uri).get_database()
+
+doi_index_to_be_dropped = IndexModel("DOI")
+
+doi_index = IndexModel(
+            "DOI", partialFilterExpression={"DOI": {"$type": "string"}}, unique=True
+        )
+references = db['references']
+
+references.drop_index([('DOI', 1)])
+references.create_indexes([doi_index])
+

--- a/splash/api/main.py
+++ b/splash/api/main.py
@@ -1,6 +1,9 @@
 import logging
+from splash.service.models import SplashMetadataAllowExtra
 
 from fastapi.responses import JSONResponse
+
+from fastapi.encoders import jsonable_encoder
 
 from splash.service.base import EtagMismatchError
 
@@ -77,7 +80,13 @@ def setup_services():
 async def handle_wrong_etag(response, exc):
     return JSONResponse(
         status_code=412,
-        content={"err": "etag_mismatch_error", "etag": exc.etag},
+        content={
+            "err": "etag_mismatch_error",
+            "etag": exc.etag,
+            # Parse to make sure that optional fields, such as archive,
+            # are inserted as None and not left out
+            "splash_md": jsonable_encoder(SplashMetadataAllowExtra.parse_obj(exc.splash_md)),
+        },
     )
 
 

--- a/splash/api/models.py
+++ b/splash/api/models.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+class ArchiveActions(str, Enum):
+    archive = 'archive'
+    restore = 'restore'
+
+
+class PatchBody(BaseModel):
+    archive_action: ArchiveActions

--- a/splash/pages/__init__.py
+++ b/splash/pages/__init__.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Extra, constr
 
 
 class ReferenceDois(BaseModel):
-    doi: constr(min_length=1)
+    uid: constr(min_length=1)
     in_text: StrictBool
 
 

--- a/splash/references/__init__.py
+++ b/splash/references/__init__.py
@@ -1,10 +1,13 @@
+from typing import Optional
+
+from pydantic.types import constr
 from splash.service import CreatedDocument
 from pydantic import BaseModel, Extra
 
 
 class NewReference(BaseModel):
-    DOI: str
-    origin_url: str
+    DOI: Optional[constr(min_length=1)] = None
+    origin_url: Optional[constr(min_length=1)] = None
 
     class Config:
         extra = Extra.allow
@@ -12,6 +15,7 @@ class NewReference(BaseModel):
 
 class Reference(NewReference, CreatedDocument):
     pass
+
 
 class UpdateReference(NewReference):
     pass

--- a/splash/references/references_routes.py
+++ b/splash/references/references_routes.py
@@ -67,7 +67,7 @@ def read_reference_by_doi(
         doi: str,
         current_user: User = Security(get_current_user)):
 
-    reference_dict = services.references.retrieve_one(current_user, doi=doi)
+    reference_dict = services.references.retrieve_by_doi(current_user, doi=doi)
 
     if reference_dict is None:
         raise HTTPException(
@@ -75,28 +75,6 @@ def read_reference_by_doi(
             detail="Not found",
         )
     return reference_dict
-
-
-@ references_router.put("/doi/{doi:path}", tags=['compounds'], response_model=CreateReferenceResponse)
-def replace_reference_by_doi(
-        doi: str,
-        reference: UpdateReference,
-        current_user: User = Security(get_current_user),
-        if_match: Optional[str] = Header(None)):
-    # It is necessary to convert to json first, then create a dict,
-    #  because if we convert straight to dict
-    # There are enum types in the dict that won't serialize when we try to save to Mongo
-    # https://github.com/samuelcolvin/pydantic/issues/133
-
-    response = services.references.update(current_user, json.loads(reference.json()), doi=doi, etag=if_match)
-
-    if response is None:
-        raise HTTPException(
-            status_code=404,
-            detail="Not found",
-        )
-    return response
-
 
 @ references_router.put("/uid/{uid}", tags=['compounds'], response_model=CreateReferenceResponse)
 def replace_reference_by_uid(

--- a/splash/references/references_routes.py
+++ b/splash/references/references_routes.py
@@ -67,14 +67,14 @@ def read_reference_by_doi(
         doi: str,
         current_user: User = Security(get_current_user)):
 
-    reference_dict = services.references.retrieve_by_doi(current_user, doi=doi)
+    reference_list = services.references.retrieve_by_doi(current_user, doi=doi)
 
-    if reference_dict is None:
+    if reference_list is None:
         raise HTTPException(
             status_code=404,
             detail="Not found",
         )
-    return reference_dict
+    return reference_list
 
 @ references_router.put("/uid/{uid}", tags=['compounds'], response_model=CreateReferenceResponse)
 def replace_reference_by_uid(

--- a/splash/references/references_service.py
+++ b/splash/references/references_service.py
@@ -13,34 +13,18 @@ class ReferencesService(MongoService):
         full_text_index = IndexModel([("$**", TEXT)])
         # This allows us to ensure that all DOIs that are of type string are unique
         # which ensures that we can have multiple null DOIs but no duplicate string DOIs
-        doi_index = IndexModel(
-            "DOI", partialFilterExpression={"DOI": {"$type": "string"}}, unique=True
-        )
+        doi_index = IndexModel("DOI")
         self._collection.create_indexes([full_text_index, doi_index])
         super()._create_indexes()
 
     def create(self, current_user: User, reference: NewReference):
         return super().create(current_user=current_user, data=reference)
 
-    def retrieve_one(
-        self, current_user: User, uid: str = None, doi: str = None
-    ) -> Reference:
-        if uid is None and doi is None:
-            raise TypeError("either param uid or doi must be a string.")
-        if uid is not None and doi is not None:
-            raise TypeError("either param uid or doi must be None")
-        if uid:
-            reference_dict = super().retrieve_one(current_user, uid)
-            if reference_dict is None:
-                return None
-            return Reference(**reference_dict)
-        if doi:
-            # The $type is so that we ignore all null values, thus allowing us to use the
-            # partial unique index we created on the DOI field
-            reference_dict = self._collection.find_one({"DOI": {'$eq': doi, '$type': 'string'}}, {"_id": False})
-            if reference_dict is None:
-                return None
-            return Reference(**reference_dict)
+    def retrieve_one(self, current_user: User, uid) -> Reference:
+        reference_dict = super().retrieve_one(current_user, uid)
+        if reference_dict is None:
+            return None
+        return Reference(**reference_dict)
 
     def retrieve_multiple(
         self,
@@ -53,6 +37,20 @@ class ReferencesService(MongoService):
         for reference_dict in cursor:
             yield Reference(**reference_dict)
 
+    def retrieve_by_doi(
+        self,
+        current_user: User,
+        doi,
+        page: int = 1,
+        page_size=10,
+    ):
+        return self.retrieve_multiple(
+            current_user,
+            page=page,
+            page_size=page_size,
+            query={"DOI": {"$eq": doi, "$type": "string"}},
+        )
+
     def search(self, current_user: User, search, page: int = 1, page_size=10):
         query = {"$text": {"$search": search}}
         return self.retrieve_multiple(
@@ -63,11 +61,10 @@ class ReferencesService(MongoService):
         self,
         current_user: User,
         data: NewReference,
-        uid: str = None,
-        doi: str = None,
+        uid,
         etag: str = None,
     ):
-        old_data_dict = self.retrieve_one(current_user, uid=uid, doi=doi)
+        old_data_dict = self.retrieve_one(current_user, uid)
         if old_data_dict is None:
             return None
         old_data_dict = old_data_dict.dict()

--- a/splash/references/references_service.py
+++ b/splash/references/references_service.py
@@ -8,10 +8,14 @@ from ..users import User
 class ReferencesService(MongoService):
     def __init__(self, db, collection_name):
         super().__init__(db, collection_name)
-    
+
     def _create_indexes(self):
         full_text_index = IndexModel([("$**", TEXT)])
-        doi_index = IndexModel("DOI")
+        # This allows us to ensure that all DOIs that are of type string are unique
+        # which ensures that we can have multiple null DOIs but no duplicate string DOIs
+        doi_index = IndexModel(
+            "DOI", partialFilterExpression={"DOI": {"$type": "string"}}, unique=True
+        )
         self._collection.create_indexes([full_text_index, doi_index])
         super()._create_indexes()
 
@@ -31,28 +35,37 @@ class ReferencesService(MongoService):
                 return None
             return Reference(**reference_dict)
         if doi:
-            reference_dict = self._collection.find_one({"DOI": doi}, {"_id": False})
+            # The $type is so that we ignore all null values, thus allowing us to use the
+            # partial unique index we created on the DOI field
+            reference_dict = self._collection.find_one({"DOI": {'$eq': doi, '$type': 'string'}}, {"_id": False})
             if reference_dict is None:
                 return None
             return Reference(**reference_dict)
 
     def retrieve_multiple(
-        self, current_user: User, page: int = 1, query=None, page_size=10, 
+        self,
+        current_user: User,
+        page: int = 1,
+        query=None,
+        page_size=10,
     ):
         cursor = super().retrieve_multiple(current_user, page, query, page_size)
         for reference_dict in cursor:
             yield Reference(**reference_dict)
 
     def search(self, current_user: User, search, page: int = 1, page_size=10):
-        query = {
-            "$text": {'$search': search}
-        }
+        query = {"$text": {"$search": search}}
         return self.retrieve_multiple(
             current_user, page=page, page_size=page_size, query=query
         )
 
     def update(
-        self, current_user: User, data: NewReference, uid: str = None, doi: str = None, etag: str = None
+        self,
+        current_user: User,
+        data: NewReference,
+        uid: str = None,
+        doi: str = None,
+        etag: str = None,
     ):
         old_data_dict = self.retrieve_one(current_user, uid=uid, doi=doi)
         if old_data_dict is None:

--- a/splash/service/authorization.py
+++ b/splash/service/authorization.py
@@ -27,3 +27,16 @@ class TeamBasedChecker(Checker):
 
     def can_do(self, user: User, resource, action: Action, teams=List[Team], **kwargs):
         raise NotImplementedError
+
+
+class NotAuthorized(Exception):
+    pass
+
+
+# decorator for checking admin status of a user
+def authorize_admin_action(func):
+    def wrapper(self, current_user: User, *args, **kwargs):
+        if current_user.splash_md.admin is True:
+            return func(self, current_user, *args, **kwargs)
+        raise NotAuthorized('user is not an admin')
+    return wrapper

--- a/splash/service/base.py
+++ b/splash/service/base.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 import logging
-from splash.service.models import SplashMetadata
+from splash.service.models import SplashMetadata, VersionedSplashMetadata
 import uuid
 from datetime import datetime
 from splash.users import User
@@ -12,6 +12,51 @@ from pymongo import ASCENDING
 ValidationIssue = namedtuple("ValidationIssue", "description, location, exception")
 
 logger = logging.getLogger("splash.service")
+
+
+# This is a decorator which ensures that none of fields in SplashMetadata 
+# Are being modified. We only want these fields to be modified by MongoService
+# It also ensures that the uid is not being modified
+def validate_base_metadata(func):
+    def wrapper(self, current_user: User, data: dict, *args, **kwargs):
+        if "uid" in data:
+            raise UidInDictError("Document should not have uid field")
+
+        if "splash_md" not in data:
+            return func(self, current_user, data, *args, **kwargs)
+
+        basic_md_fields = SplashMetadata.__dict__["__fields__"]
+        # The top layer that called this cannot mutate
+        # any of these fields. They should only be mutated by
+        # this service layer
+        for field in basic_md_fields:
+            if field in data["splash_md"]:
+                raise ImmutableMetadataField(
+                    f"Cannot mutate field: `{field}` in `splash_md`"
+                )
+        return func(self, current_user, data, *args, **kwargs)
+    return wrapper
+
+
+# This is a decorator which ensures that none of the fields in VersionedSplashMetadata
+# are being modified.
+def validate_versioned_metadata(func):
+    def wrapper(self, current_user: User, data: dict, *args, **kwargs):
+
+        if "splash_md" not in data:
+            return func(self, current_user, data, *args, **kwargs)
+
+        versioned_md_fields = VersionedSplashMetadata.__dict__["__fields__"]
+        # The top layer that called this cannot mutate
+        # any of these fields. They should only be mutated by
+        # this service layer
+        for field in versioned_md_fields:
+            if field in data["splash_md"]:
+                raise ImmutableMetadataField(
+                    f"Cannot mutate field: `{field}` in `splash_md`"
+                )
+        return func(self, current_user, data, *args, **kwargs)
+    return wrapper
 
 
 class BadPageArgument(Exception):
@@ -49,21 +94,14 @@ class MongoService:
         sort_index = IndexModel([("splash_md.last_edit", DESCENDING), ("uid", DESCENDING)])
         self._collection.create_indexes([uid_unique_index, creator_index, sort_index])
 
+    @validate_base_metadata
     def create(self, current_user: User, data: dict):
-        if "uid" in data:
-            raise UidInDictError("Document should not have uid field")
         uid = uuid.uuid4()
         data["uid"] = str(uid)
 
         if "splash_md" not in data:
             data["splash_md"] = {}
 
-        basic_md_fields = SplashMetadata.__dict__["__fields__"]
-        for field in basic_md_fields:
-            if field in data["splash_md"]:
-                raise ImmutableMetadataField(
-                    f"Cannot mutate field: `{field}` in `splash_md`"
-                )
         # remove the microsecond because mongo will truncate past a certain amount of decimal places
         data["splash_md"]["create_date"] = datetime.utcnow().replace(microsecond=0)
         data["splash_md"]["last_edit"] = data["splash_md"]["create_date"]
@@ -111,6 +149,7 @@ class MongoService:
             cursor.sort(sort).collation(Collation("en_US")).skip(skips).limit(page_size)
         )
 
+    @validate_base_metadata
     def update(self, current_user: User, data: dict, uid: str, etag=None):
         data["uid"] = uid
 
@@ -131,16 +170,8 @@ class MongoService:
             # If the top layer is also sending in metadata
             # then we want to merge it with the metadata already in the
             # document
-            basic_md_fields = SplashMetadata.__dict__["__fields__"]
-            for field in basic_md_fields:
-                # The top layer that called this cannot mutate
-                # any of these fields. They should only be mutated by
-                # this service layer
-                if field in data["splash_md"]:
-                    raise ImmutableMetadataField(
-                        f"Cannot mutate field: `{field}` in `splash_md`"
-                    )
-                data["splash_md"][field] = metadata[field]
+            metadata.update(data["splash_md"])
+            data["splash_md"] = metadata
         # Update the edit_record array and last edit timestamp
         # remove the microsecond because mongo will truncate past a certain amount of decimal places
         data["splash_md"]["last_edit"] = datetime.utcnow().replace(microsecond=0)
@@ -176,15 +207,10 @@ class VersionedMongoService(MongoService):
         super().__init__(db, collection_name)
         self._versions_svc = HistoricMongoService(db, revisions_collection_name)
 
+    @validate_versioned_metadata
     def update(self, current_user: User, data: dict, uid: str, etag=None):
-        if "splash_md" in data:
-            if "version" in data["splash_md"]:
-                raise ImmutableMetadataField(
-                    "Cannot mutate field: `version` in `splash_md`"
-                )
-        else:
+        if "splash_md" not in data:
             data["splash_md"] = {}
-
         current_document = super().retrieve_one(current_user, uid)
         if current_document is None:
             raise ObjectNotFoundError
@@ -193,13 +219,9 @@ class VersionedMongoService(MongoService):
         self._versions_svc._collection.insert_one(current_document)
         return result
 
+    @validate_versioned_metadata
     def create(self, current_user: User, data: dict):
-        if "splash_md" in data:
-            if "version" in data["splash_md"]:
-                raise ImmutableMetadataField(
-                    "Cannot mutate field: `version` in `splash_md`"
-                )
-        else:
+        if "splash_md" not in data:
             data["splash_md"] = {}
         data["splash_md"]["version"] = 1
         return super().create(current_user, data)

--- a/splash/service/base.py
+++ b/splash/service/base.py
@@ -184,6 +184,7 @@ class MongoService:
             raise EtagMismatchError(
                 f"Etag argument `{etag}` does not match current etag: `{ metadata['etag'] }`",
                 metadata["etag"],
+                metadata,
             )
 
         if "splash_md" not in data:
@@ -330,8 +331,9 @@ class ImmutableMetadataField(KeyError):
 
 
 class EtagMismatchError(ValueError):
-    def __init__(self, message, etag):
+    def __init__(self, message, etag, splash_md):
         self.etag = etag
+        self.splash_md = splash_md
         super().__init__(message, etag)
 
 

--- a/splash/service/base.py
+++ b/splash/service/base.py
@@ -1,8 +1,9 @@
 from collections import namedtuple
 import logging
+from typing import Type
 
 from pydantic.main import BaseModel
-from splash.service.models import SplashMetadata, VersionedSplashMetadata
+from splash.service.models import PrivateSplashMetadata, PrivateVersionedSplashMetadata
 import uuid
 from datetime import datetime
 from splash.users import User
@@ -37,9 +38,11 @@ def validate_base_metadata(func):
             # The top layer that called this cannot mutate
             # any of these fields. They should only be mutated by
             # the service layer that uses this decorator or a lower one
-        field = check_for_fields(SplashMetadata, data)
+        field = check_for_fields(PrivateSplashMetadata, data)
         if field is not None:
-            raise ImmutableMetadataField(f"Cannot mutate field: `{field}` in `splash_md`")
+            raise ImmutableMetadataField(
+                f"Cannot mutate field: `{field}` in `splash_md`"
+            )
 
         return func(self, current_user, data, *args, **kwargs)
 
@@ -54,9 +57,11 @@ def validate_versioned_metadata(func):
         if "splash_md" not in data:
             return func(self, current_user, data, *args, **kwargs)
 
-        field = check_for_fields(VersionedSplashMetadata, data)
+        field = check_for_fields(PrivateVersionedSplashMetadata, data)
         if field is not None:
-            raise ImmutableMetadataField(f"Cannot mutate field: `{field}` in `splash_md`")
+            raise ImmutableMetadataField(
+                f"Cannot mutate field: `{field}` in `splash_md`"
+            )
         return func(self, current_user, data, *args, **kwargs)
 
     return wrapper
@@ -136,17 +141,27 @@ class MongoService:
         # IF YOU WANT TO MAKE SURE IT STAYS CONSISTENT,
         # PLACE A UID AT THE END: https://docs.mongodb.com/manual/reference/method/cursor.sort/#sort-consistency
         sort=[("splash_md.last_edit", DESCENDING), ("uid", DESCENDING)],
+        exclude_archived=True,
     ):
         if type(sort) is not list:
             raise TypeError("`sort` argument must be of type list")
         if page <= 0:
             raise BadPageArgument("Page parameter must greater than 0")
 
+        exclude_archived_query = {
+            "splash_md.archived": {'$ne': True}
+        }
         # Calculate number of documents to skip
         skips = page_size * (page - 1)
-        # Skip and limit
+
         if query is None:
             query = {}
+        elif type(query) is not dict:
+            raise TypeError("`query` argument must be of type dict or None")
+
+        if exclude_archived is True:
+            query = {"$and": [exclude_archived_query, query]}
+
         cursor = self._collection.find(query, {"_id": False})
 
         # Return documents
@@ -159,6 +174,8 @@ class MongoService:
         data["uid"] = uid
 
         current_document = MongoService.retrieve_one(self, current_user, uid)
+        if current_document is None:
+            raise ObjectNotFoundError()
 
         metadata = current_document["splash_md"]
 
@@ -189,6 +206,35 @@ class MongoService:
         if status.matched_count == 0:
             raise ObjectNotFoundError
         return {"uid": data["uid"], "splash_md": data["splash_md"]}
+
+    def archive_action(self, current_user: User, action: str, uid, etag=None):
+        if action not in ("restore", "archive"):
+            raise ValueError(
+                "third positional argument `action` must match the string 'archive' or 'restore'"
+            )
+        stored_doc = MongoService.retrieve_one(self, current_user, uid)
+        if stored_doc is None:
+            raise ObjectNotFoundError()
+
+        if action == "archive":
+            if "archived" not in stored_doc["splash_md"] or stored_doc["splash_md"][
+                "archived"
+            ] in (False, None):
+                new_doc = stored_doc
+                new_doc["splash_md"] = {"archived": True}
+                new_doc.pop("uid")
+                return MongoService.update(self, current_user, new_doc, uid, etag=etag)
+            raise ArchiveConflictError()
+        if action == "restore":
+            if "archived" in stored_doc["splash_md"] and stored_doc["splash_md"]["archived"] is True:
+                new_doc = stored_doc
+                new_doc["splash_md"] = {"archived": False}
+                new_doc.pop("uid")
+                return MongoService.update(self, current_user, new_doc, uid, etag=etag)
+            raise RestoreConflictError()
+
+    def retrieve_archived(self, current_user: User, page=1, page_size=10):
+        return MongoService.retrieve_multiple(self, current_user, page=page, page_size=page_size, query={'splash_md.archived': True}, exclude_archived=False)
 
     def delete(self, current_user: User, uid):
         status = self._collection.delete_one({"uid": uid})
@@ -287,3 +333,11 @@ class EtagMismatchError(ValueError):
     def __init__(self, message, etag):
         self.etag = etag
         super().__init__(message, etag)
+
+
+class ArchiveConflictError(Exception):
+    pass
+
+
+class RestoreConflictError(Exception):
+    pass

--- a/splash/service/models.py
+++ b/splash/service/models.py
@@ -2,6 +2,8 @@ from typing import List, Optional
 from pydantic import BaseModel
 from datetime import datetime
 
+from pydantic.main import Extra
+
 
 class EditElement(BaseModel):
     date: datetime
@@ -21,6 +23,11 @@ class SplashMetadata(PrivateSplashMetadata):
     archived: Optional[bool] = None
 
 
+class SplashMetadataAllowExtra(SplashMetadata):
+    class Config:
+        extra = Extra.allow
+
+
 # This model is for fields that can only be changed by the base mongo versioned service
 class PrivateVersionedSplashMetadata(BaseModel):
     version: int
@@ -38,3 +45,4 @@ class CreatedDocument(BaseModel):
 class CreatedVersionedDocument(BaseModel):
     uid: str
     splash_md: VersionedSplashMetadata
+

--- a/splash/service/models.py
+++ b/splash/service/models.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 from pydantic import BaseModel
 from datetime import datetime
 
@@ -8,7 +8,8 @@ class EditElement(BaseModel):
     user: str
 
 
-class SplashMetadata(BaseModel):
+# This model is for fields that can only be changed by the base mongo service
+class PrivateSplashMetadata(BaseModel):
     creator: str
     create_date: datetime
     last_edit: datetime
@@ -16,8 +17,17 @@ class SplashMetadata(BaseModel):
     etag: str
 
 
-class VersionedSplashMetadata(SplashMetadata):
+class SplashMetadata(PrivateSplashMetadata):
+    archived: Optional[bool] = None
+
+
+# This model is for fields that can only be changed by the base mongo versioned service
+class PrivateVersionedSplashMetadata(BaseModel):
     version: int
+
+
+class VersionedSplashMetadata(SplashMetadata, PrivateVersionedSplashMetadata):
+    pass
 
 
 class CreatedDocument(BaseModel):

--- a/splash/test/conftest.py
+++ b/splash/test/conftest.py
@@ -7,4 +7,5 @@ from .fixtures.add import (
     teams_service,
     mock_collation_prop,
     test_user1,
+    # fresh_mongodb,
 )

--- a/splash/test/fixtures/add.py
+++ b/splash/test/fixtures/add.py
@@ -9,7 +9,7 @@ from splash.pages.pages_routes import set_pages_service
 from splash.pages.pages_service import PagesService
 from splash.references.references_routes import set_references_service
 from splash.references.references_service import ReferencesService
-from splash.users import NewUser
+from splash.users import NewUser, User
 from splash.users.users_routes import set_users_service
 from splash.users.users_service import UsersService
 from splash.runs.runs_routes import set_runs_service
@@ -55,11 +55,15 @@ def mock_collation_prop(monkeypatch):
 def mongodb():
     return db
 
+# @pytest.fixture
+# def fresh_mongodb():
+#     return mongomock.MongoClient().db
+
 
 @pytest.fixture
 def test_user1():
     return NewUser(
-        given_name="ford", family_name="prefect", email="ford@beetleguice.planet"
+        given_name="ford", family_name="prefect", email="ford@beetleguice.planet", 
     )
 
 
@@ -73,10 +77,33 @@ def test_user1():
 token_info1 = {"sub": None, "scopes": ["splash"]}
 token_info2 = {"sub": None, "scopes": ["splash"]}
 
+admin_user1 = User(
+        splash_md={
+            "creator": "NONE",
+            "create_date": "2020-01-7T13:40:53",
+            "last_edit": "2020-01-7T13:40:53",
+            "edit_record": [],
+            "etag": "f672367e-c534-4f4a-9e5a-0941dbab2d1c",
+            "admin": True
+        },
+        uid="foobar1",
+        given_name="Sauron",
+        family_name="The Dark Lord",
+        email="Sauron@mordor.net",
+    )
+
+admin_user2 = NewUser(
+        splash_md={
+            "admin": True
+        },
+        given_name="Melkor",
+        family_name="The Ainur",
+        email="Melkor@silmarillion.com",
+    )
 
 @pytest.fixture
 def splash_client(mongodb, test_user1, monkeypatch):
-    uid = users_svc.create(None, test_user1)["uid"]
+    uid = users_svc.create(admin_user1, admin_user2)["uid"]
     token_info1["sub"] = uid
     client = TestClient(app)
     return client
@@ -129,13 +156,13 @@ other_team = {
 
 @pytest.fixture(scope="session", autouse=True)
 def users():
-    user_leader_uid = users_svc.create(None, NewUser(**leader))["uid"]
-    user_same_team_uid = users_svc.create(None, NewUser(**same_team))["uid"]
-    user_other_team_uid = users_svc.create(None, NewUser(**other_team))["uid"]
+    user_leader_uid = users_svc.create(admin_user1, NewUser(**leader))["uid"]
+    user_same_team_uid = users_svc.create(admin_user1, NewUser(**same_team))["uid"]
+    user_other_team_uid = users_svc.create(admin_user1, NewUser(**other_team))["uid"]
     users = {}
-    users["leader"] = users_svc.retrieve_one(None, user_leader_uid)
-    users["same_team"] = users_svc.retrieve_one(None, user_same_team_uid)
-    users["other_team"] = users_svc.retrieve_one(None, user_other_team_uid)
+    users["leader"] = users_svc.retrieve_one(admin_user1, user_leader_uid)
+    users["same_team"] = users_svc.retrieve_one(admin_user1, user_same_team_uid)
+    users["other_team"] = users_svc.retrieve_one(admin_user1, user_other_team_uid)
     return users
 
 

--- a/splash/test/test_mongo_service.py
+++ b/splash/test/test_mongo_service.py
@@ -235,13 +235,18 @@ def test_create_with_bad_metadata(mongo_service: MongoService, request_user_1: U
 def test_update_with_good_metadata(mongo_service: MongoService, request_user_1: User):
     response = mongo_service.create(request_user_1, {"Mordor": "Mt. Doom"})
 
-    data = mongo_service.retrieve_one(request_user_1, response["uid"])
-    data.pop("splash_md")
-    data["splash_md"] = {"muteable_field": "test"}
-    data.pop("uid")
+    incoming_data = mongo_service.retrieve_one(request_user_1, response["uid"])
+    incoming_data.pop("splash_md")
+    incoming_data["splash_md"] = {"muteable_field": "test"}
+    incoming_data.pop("uid")
 
-    mongo_service.update(request_user_1, data, response["uid"])
-    assert data == mongo_service.retrieve_one(request_user_1, response["uid"])
+    mongo_service.update(request_user_1, deepcopy(incoming_data), response["uid"])
+
+    stored_data = mongo_service.retrieve_one(request_user_1, response["uid"])
+    # Make sure body stayed the same
+    equal_dicts(incoming_data, stored_data, ignore_keys)
+    # Make sure that the field was changed
+    assert incoming_data["splash_md"]["muteable_field"] == stored_data["splash_md"]["muteable_field"]
 
 
 def test_update_with_bad_metadata(mongo_service: MongoService, request_user_1: User):

--- a/splash/test/test_mongo_service.py
+++ b/splash/test/test_mongo_service.py
@@ -1,12 +1,15 @@
 import datetime
-from splash.service.models import SplashMetadata
+from splash.service.models import PrivateSplashMetadata
 from splash.test.testing_utils import equal_dicts
 from splash.users import User
 import pytest
 from splash.service.base import (
+    ArchiveConflictError,
     EtagMismatchError,
     MongoService,
     ImmutableMetadataField,
+    ObjectNotFoundError,
+    RestoreConflictError,
 )
 import mongomock
 from freezegun import freeze_time
@@ -122,7 +125,12 @@ def test_order_by_key(mongo_service: MongoService, request_user_1: User, monkeyp
     mongo_service.create(request_user_1, deepcopy(legolas))
     mongo_service.create(request_user_1, deepcopy(galadriel))
     mongo_service.create(request_user_1, deepcopy(elrond))
-    elves = list(mongo_service.retrieve_multiple(request_user_1, sort=[("name", 1)],))
+    elves = list(
+        mongo_service.retrieve_multiple(
+            request_user_1,
+            sort=[("name", 1)],
+        )
+    )
 
     assert len(elves) == 4
     equal_dicts(celebrimbor, elves[0], ignore_keys)
@@ -219,7 +227,7 @@ def test_create_with_good_metadata(mongo_service: MongoService, request_user_1: 
     assert response
 
 
-immutable_fields = SplashMetadata.__dict__["__fields__"]
+immutable_fields = PrivateSplashMetadata.__dict__["__fields__"]
 
 
 def test_create_with_bad_metadata(mongo_service: MongoService, request_user_1: User):
@@ -246,7 +254,10 @@ def test_update_with_good_metadata(mongo_service: MongoService, request_user_1: 
     # Make sure body stayed the same
     equal_dicts(incoming_data, stored_data, ignore_keys)
     # Make sure that the field was changed
-    assert incoming_data["splash_md"]["muteable_field"] == stored_data["splash_md"]["muteable_field"]
+    assert (
+        incoming_data["splash_md"]["muteable_field"]
+        == stored_data["splash_md"]["muteable_field"]
+    )
 
 
 def test_update_with_bad_metadata(mongo_service: MongoService, request_user_1: User):
@@ -264,6 +275,14 @@ def test_update_with_bad_metadata(mongo_service: MongoService, request_user_1: U
             )
         assert mongo_service.retrieve_one(request_user_1, response["uid"]) == data
 
+
+def test_update_does_not_exist(mongo_service: MongoService, request_user_1: User):
+    mongo_service.create(
+        request_user_1,
+        deepcopy(celebrimbor),
+    )
+    with pytest.raises(ObjectNotFoundError):
+        mongo_service.update(request_user_1, {}, "uid_does_not_exist")
 
 def test_etag_functionality(mongo_service: MongoService, request_user_1: User):
     response = mongo_service.create(
@@ -287,7 +306,182 @@ def test_etag_functionality(mongo_service: MongoService, request_user_1: User):
         mongo_service.update(request_user_1, deepcopy(celebrimbor_3), uid, etag=etag1)
 
     doc_2 = mongo_service.retrieve_one(request_user_1, uid)
-    assert exc.value.args[0] == f"Etag argument `{etag1}` does not match current etag: `{etag2}`"
+    assert (
+        exc.value.args[0]
+        == f"Etag argument `{etag1}` does not match current etag: `{etag2}`"
+    )
     assert exc.value.etag == etag2
     # make sure no changes were made
     assert doc_2 == document_2
+
+
+# This is to make sure that documents that have None as the value work
+# The same as docs that don't have any 'archived' key
+archived_status_none = {
+    'splash_md': {
+        'archived': None,
+    },
+    'test': 'test'
+}
+
+
+def test_archive_restore(mongo_service: MongoService, request_user_1: User):
+    with freeze_time(mock_times[0], tz_offset=-4, auto_tick_seconds=15):
+        response1 = mongo_service.create(
+            request_user_1,
+            deepcopy(celebrimbor),
+        )
+
+        mongo_service.create(
+            request_user_1,
+            deepcopy(legolas),
+        )
+
+        mongo_service.create(
+            request_user_1,
+            deepcopy(archived_status_none)
+        )
+
+        patch_resp = mongo_service.archive_action(request_user_1, "archive", response1["uid"])
+
+        assert patch_resp == {"uid": response1["uid"], "splash_md": mongo_service.retrieve_one(request_user_1, response1["uid"])["splash_md"]}
+
+        non_archived_docs = list(mongo_service.retrieve_multiple(request_user_1))
+
+        assert len(non_archived_docs) == 2
+        equal_dicts(archived_status_none, non_archived_docs[0], ignore_keys)
+        equal_dicts(legolas, non_archived_docs[1], ignore_keys)
+
+        archived_celebrimbor = mongo_service.retrieve_one(request_user_1, response1["uid"])
+        assert archived_celebrimbor["splash_md"]["archived"] is True
+        equal_dicts(archived_celebrimbor, celebrimbor, ignore_keys)
+
+        patch_resp = mongo_service.archive_action(request_user_1, "restore", response1["uid"])
+        assert patch_resp == {"uid": response1["uid"], "splash_md": mongo_service.retrieve_one(request_user_1, response1["uid"])["splash_md"]}
+
+        non_archived_docs = list(mongo_service.retrieve_multiple(request_user_1))
+
+        assert len(non_archived_docs) == 3
+
+        equal_dicts(non_archived_docs[0], celebrimbor, ignore_keys)
+        assert non_archived_docs[0]["splash_md"]["archived"] is False
+        equal_dicts(non_archived_docs[1], archived_status_none, ignore_keys)
+        equal_dicts(non_archived_docs[2], legolas, ignore_keys)
+
+
+def test_get_archived(mongo_service: MongoService, request_user_1: User):
+    response1 = mongo_service.create(
+        request_user_1,
+        deepcopy(celebrimbor),
+    )
+
+    mongo_service.create(
+        request_user_1,
+        deepcopy(archived_status_none),
+    )
+
+    archived_docs = list(mongo_service.retrieve_archived(request_user_1))
+    assert len(archived_docs) == 0
+
+    mongo_service.archive_action(request_user_1, "archive", response1["uid"])
+    archived_docs = list(mongo_service.retrieve_archived(request_user_1))
+    assert len(archived_docs) == 1
+    equal_dicts(archived_docs[0], celebrimbor, ignore_keys)
+
+    mongo_service.archive_action(request_user_1, "restore", response1["uid"])
+    archived_docs = list(mongo_service.retrieve_archived(request_user_1))
+    assert len(archived_docs) == 0
+
+
+def test_retrieve_multiple_archived_options(mongo_service: MongoService, request_user_1: User):
+    response1 = mongo_service.create(
+        request_user_1,
+        deepcopy(celebrimbor),
+    )
+
+    mongo_service.create(
+        request_user_1,
+        deepcopy(legolas),
+    )
+
+    mongo_service.create(
+        request_user_1,
+        deepcopy(archived_status_none)
+    )
+
+    mongo_service.archive_action(request_user_1, "archive", response1["uid"])
+
+    all_docs = list(mongo_service.retrieve_multiple(request_user_1, exclude_archived=False))
+    assert len(all_docs) == 3
+
+    no_docs = list(mongo_service.retrieve_multiple(request_user_1, query={"name": "Celebrimbor"}))
+    assert len(no_docs) == 0
+
+    celebrimbor_docs = list(mongo_service.retrieve_multiple(request_user_1, query={"name": "Celebrimbor"}, exclude_archived=False))
+    assert len(celebrimbor_docs) == 1
+
+
+def test_archive_action_conflict(mongo_service: MongoService, request_user_1: User):
+    response = mongo_service.create(
+        request_user_1,
+        deepcopy(celebrimbor),
+    )
+
+    with pytest.raises(RestoreConflictError):
+        mongo_service.archive_action(request_user_1, "restore", response["uid"])
+
+    stored = mongo_service.retrieve_one(request_user_1, response["uid"])
+    assert "archived" not in stored["splash_md"]
+
+    mongo_service.archive_action(request_user_1, "archive", response["uid"])
+
+    with pytest.raises(ArchiveConflictError):
+        mongo_service.archive_action(request_user_1, "archive", response["uid"])
+
+    stored = mongo_service.retrieve_one(request_user_1, response["uid"])
+    assert stored["splash_md"]["archived"] is True
+
+    mongo_service.archive_action(request_user_1, "restore", response["uid"])
+
+    with pytest.raises(RestoreConflictError):
+        mongo_service.archive_action(request_user_1, "restore", response["uid"])
+
+    stored = mongo_service.retrieve_one(request_user_1, response["uid"])
+    assert stored["splash_md"]["archived"] is False
+
+
+def test_bad_archive_action(mongo_service: MongoService, request_user_1: User):
+    response = mongo_service.create(
+        request_user_1,
+        deepcopy(celebrimbor),
+    )
+    with pytest.raises(ValueError, match="third positional argument `action` must match the string 'archive' or 'restore'"):
+        mongo_service.archive_action(request_user_1, "bad_action", response["uid"])
+
+
+def test_archive_and_restore_does_not_exist(mongo_service: MongoService, request_user_1: User):
+    mongo_service.create(
+        request_user_1,
+        deepcopy(celebrimbor),
+    )
+    with pytest.raises(ObjectNotFoundError):
+        mongo_service.archive_action(request_user_1, 'archive', "uid_does_not_exist")
+
+    with pytest.raises(ObjectNotFoundError):
+        mongo_service.archive_action(request_user_1, 'restore', "uid_does_not_exist")
+
+
+def test_archive_and_restore_etag(mongo_service: MongoService, request_user_1: User):
+    response = mongo_service.create(
+        request_user_1,
+        deepcopy(celebrimbor),
+    )
+    with pytest.raises(EtagMismatchError):
+        mongo_service.archive_action(request_user_1, 'archive', response["uid"], etag="bad_etag")
+
+    response = mongo_service.archive_action(request_user_1, 'archive', response["uid"], etag=response['splash_md']['etag'])
+
+    with pytest.raises(EtagMismatchError):
+        mongo_service.archive_action(request_user_1, 'restore', response["uid"], etag="bad_etag")
+
+    mongo_service.archive_action(request_user_1, 'restore', response["uid"], etag=response['splash_md']['etag'])

--- a/splash/test/test_mongo_service.py
+++ b/splash/test/test_mongo_service.py
@@ -311,6 +311,7 @@ def test_etag_functionality(mongo_service: MongoService, request_user_1: User):
         == f"Etag argument `{etag1}` does not match current etag: `{etag2}`"
     )
     assert exc.value.etag == etag2
+    assert exc.value.splash_md == document_2['splash_md']
     # make sure no changes were made
     assert doc_2 == document_2
 

--- a/splash/test/test_mongo_service.py
+++ b/splash/test/test_mongo_service.py
@@ -232,6 +232,18 @@ def test_create_with_bad_metadata(mongo_service: MongoService, request_user_1: U
             mongo_service.create(request_user_1, {"splash_md": {field: "test_value"}})
 
 
+def test_update_with_good_metadata(mongo_service: MongoService, request_user_1: User):
+    response = mongo_service.create(request_user_1, {"Mordor": "Mt. Doom"})
+
+    data = mongo_service.retrieve_one(request_user_1, response["uid"])
+    data.pop("splash_md")
+    data["splash_md"] = {"muteable_field": "test"}
+    data.pop("uid")
+
+    mongo_service.update(request_user_1, data, response["uid"])
+    assert data == mongo_service.retrieve_one(request_user_1, response["uid"])
+
+
 def test_update_with_bad_metadata(mongo_service: MongoService, request_user_1: User):
     response = mongo_service.create(request_user_1, {"Mordor": "Mt. Doom"})
 

--- a/splash/test/test_pages_api.py
+++ b/splash/test/test_pages_api.py
@@ -409,7 +409,7 @@ new_page = {
                 in several crops [[4]](#4) .\n - Small, neutral solute\n\t - Boric acid is a small solute, with an \
                 estimated Stokes radius of 1.6 Å [[5]](#5) , compared to 1.8 Å and 1.2 Å for sodium and chloride, \
                 respectively [[6]](#6) .\n\t - The Stokes radius of borate has been estimated as 2.6 Å [[7]](#7) .",
-    "references": [{"doi": "10.XX/XXXX", "in_text": False}],
+    "references": [{"uid": "ffff-ffff-fffff-fffff", "in_text": False}],
 }
 
 empty_string_documentation = {

--- a/splash/test/test_pages_api.py
+++ b/splash/test/test_pages_api.py
@@ -3,7 +3,11 @@ import json
 
 import pytest
 
-from .testing_utils import generic_test_api_crud, generic_test_etag_functionality
+from .testing_utils import (
+    equal_dicts,
+    generic_test_api_crud,
+    generic_test_etag_functionality,
+)
 
 
 @pytest.mark.usefixtures("splash_client", "token_header")
@@ -40,12 +44,11 @@ def test_retrieve_by_type(api_url_root, splash_client, token_header):
     post_resp1 = splash_client.post(
         url,
         json={
-                "title": "Maiar",
-                "page_type": "mythical_animals",
-
-                "documentation": "Hello",
-                "references": [],
-            },
+            "title": "Maiar",
+            "page_type": "mythical_animals",
+            "documentation": "Hello",
+            "references": [],
+        },
         headers=token_header,
     )
     assert (
@@ -54,11 +57,11 @@ def test_retrieve_by_type(api_url_root, splash_client, token_header):
     post_resp2 = splash_client.post(
         url,
         json={
-                "title": "Troll",
-                "page_type": "mythical_animals",
-                "documentation": "Hello",
-                "references": [],
-            },
+            "title": "Troll",
+            "page_type": "mythical_animals",
+            "documentation": "Hello",
+            "references": [],
+        },
         headers=token_header,
     )
     assert (
@@ -67,11 +70,11 @@ def test_retrieve_by_type(api_url_root, splash_client, token_header):
     post_resp3 = splash_client.post(
         url,
         json={
-                "title": "Wand",
-                "page_type": "mythical_items",
-                "documentation": "Hello",
-                "references": [],
-            },
+            "title": "Wand",
+            "page_type": "mythical_items",
+            "documentation": "Hello",
+            "references": [],
+        },
         headers=token_header,
     )
     assert (
@@ -95,11 +98,11 @@ def test_versioning(api_url_root, splash_client, token_header):
     post_resp = splash_client.post(
         url,
         json={
-                "title": "Drake",
-                "page_type": "mythical_animals",
-                "documentation": "Hello",
-                "references": [],
-            },
+            "title": "Drake",
+            "page_type": "mythical_animals",
+            "documentation": "Hello",
+            "references": [],
+        },
         headers=token_header,
     )
     uid = post_resp.json()["uid"]
@@ -111,11 +114,11 @@ def test_versioning(api_url_root, splash_client, token_header):
     put_resp = splash_client.put(
         url + "/" + uid,
         json={
-                "title": "Drake/Dragon",
-                "page_type": "mythical_animals",
-                "documentation": "Hello",
-                "references": [],
-            },
+            "title": "Drake/Dragon",
+            "page_type": "mythical_animals",
+            "documentation": "Hello",
+            "references": [],
+        },
         headers=token_header,
     )
     response = splash_client.get(url + "/" + uid, headers=token_header)
@@ -162,11 +165,11 @@ def test_versioning(api_url_root, splash_client, token_header):
     put_resp = splash_client.put(
         url + "/" + "does not exist",
         json={
-                "title": "Drake/Dragon",
-                "page_type": "mythical_animals",
-                "documentation": "Hello",
-                "references": [],
-            },
+            "title": "Drake/Dragon",
+            "page_type": "mythical_animals",
+            "documentation": "Hello",
+            "references": [],
+        },
         headers=token_header,
     )
     assert (
@@ -191,12 +194,12 @@ def test_versioning(api_url_root, splash_client, token_header):
     put_resp = splash_client.put(
         url + "/" + uid,
         json={
-                "title": "Drake/Dragon",
-                "page_type": "mythical_animals",
-                "documentation": "test",
-                "document_version": 3,
-                "references": [],
-            },
+            "title": "Drake/Dragon",
+            "page_type": "mythical_animals",
+            "documentation": "test",
+            "document_version": 3,
+            "references": [],
+        },
         headers=token_header,
     )
 
@@ -207,12 +210,12 @@ def test_versioning(api_url_root, splash_client, token_header):
     post_resp = splash_client.post(
         url,
         json={
-                "title": "Drake/Dragon",
-                "page_type": "mythical_animals",
-                "documentation": "test",
-                "document_version": 3,
-                "references": [],
-            },
+            "title": "Drake/Dragon",
+            "page_type": "mythical_animals",
+            "documentation": "test",
+            "document_version": 3,
+            "references": [],
+        },
         headers=token_header,
     )
 
@@ -226,11 +229,11 @@ def test_retrieve_num_versions(api_url_root, splash_client, token_header):
     post_resp = splash_client.post(
         url,
         json={
-                "title": "Beethoven's 5th",
-                "page_type": "songs",
-                "documentation": "test",
-                "references": [],
-            },
+            "title": "Beethoven's 5th",
+            "page_type": "songs",
+            "documentation": "test",
+            "references": [],
+        },
         headers=token_header,
     )
     uid = post_resp.json()["uid"]
@@ -242,12 +245,12 @@ def test_retrieve_num_versions(api_url_root, splash_client, token_header):
 
     response = splash_client.put(
         url + "/" + uid,
-        json= {
-                "title": "Schicksals-Sinfonie",
-                "page_type": "songs",
-                "documentation": "test",
-                "references": [],
-            },
+        json={
+            "title": "Schicksals-Sinfonie",
+            "page_type": "songs",
+            "documentation": "test",
+            "references": [],
+        },
         headers=token_header,
     )
     response = splash_client.get(url + "/num_versions/" + uid, headers=token_header)
@@ -259,11 +262,11 @@ def test_retrieve_num_versions(api_url_root, splash_client, token_header):
     response = splash_client.put(
         url + "/" + uid,
         json={
-                "title": "Schicksals-Sinfonie, Beethoven's 5th",
-                "page_type": "songs",
-                "documentation": "test",
-                "references": [],
-            },
+            "title": "Schicksals-Sinfonie, Beethoven's 5th",
+            "page_type": "songs",
+            "documentation": "test",
+            "references": [],
+        },
         headers=token_header,
     )
     response = splash_client.get(url + "/num_versions/" + uid, headers=token_header)
@@ -278,6 +281,123 @@ def test_retrieve_num_versions(api_url_root, splash_client, token_header):
     assert (
         response.status_code == 404
     ), f"{response.status_code}: response is {response.content}"
+
+
+def test_archive_and_restore(api_url_root, splash_client, token_header):
+    url = api_url_root + "/pages"
+    archive_req = {"archive_action": "archive"}
+    restore_req = {"archive_action": "restore"}
+    doc = {
+            "title": "Blue Jay",
+            "page_type": "birds",
+            "documentation": "This is a bird that is blue",
+            "references": [],
+        }
+
+    post_resp = splash_client.post(
+        url,
+        json=copy.deepcopy(doc),
+        headers=token_header,
+    )
+
+    assert post_resp.status_code == 200
+
+    patch_resp = splash_client.patch(
+        url + "/" + post_resp.json()["uid"], json=archive_req, headers=token_header
+    )
+    assert patch_resp.status_code == 200
+    get_resp = splash_client.get(
+        url + "/archived",
+        headers=token_header,
+    )
+    assert get_resp.status_code == 200, f'the response is {get_resp.json()}'
+    assert len(get_resp.json()) == 1
+    equal_dicts(get_resp.json()[0], doc, ignore_keys=["uid", "splash_md"])
+    assert patch_resp.json()['splash_md'] == get_resp.json()[0]['splash_md']
+    assert patch_resp.json()['uid'] == post_resp.json()['uid']
+
+    patch_resp = splash_client.patch(
+        url + "/" + post_resp.json()["uid"], json=restore_req, headers=token_header
+    )
+    assert patch_resp.status_code == 200
+    get_resp = splash_client.get(
+        url + "/archived",
+        headers=token_header,
+    )
+    assert len(get_resp.json()) == 0
+    doc_resp = splash_client.get(
+        url + "/" + post_resp.json()["uid"], headers=token_header
+    )
+    assert doc_resp.status_code == 200
+    equal_dicts(doc_resp.json(), doc, ignore_keys=["uid", "splash_md"])
+    assert patch_resp.json()['splash_md'] == doc_resp.json()['splash_md']
+    assert patch_resp.json()['uid'] == post_resp.json()['uid']
+
+
+def test_bad_archive_req(api_url_root, splash_client, token_header):
+    url = api_url_root + "/pages"
+    bad_req = {"archive_action": "action_does_not_exist"}
+    post_resp = splash_client.post(
+        url,
+        json={
+            "title": "Blue Jay",
+            "page_type": "birds",
+            "documentation": "This is a bird that is blue",
+            "references": [],
+        },
+        headers=token_header,
+    )
+
+    patch_resp = splash_client.patch(
+        url + "/" + post_resp.json()["uid"], json=bad_req, headers=token_header
+    )
+    assert patch_resp.status_code == 422
+    archives = splash_client.get(url + "/archived", headers=token_header).json()
+    assert len(archives) == 0
+
+
+def test_archive_and_restore_conflict(api_url_root, splash_client, token_header):
+    url = api_url_root + "/pages"
+    archive_req = {"archive_action": "archive"}
+    restore_req = {"archive_action": "restore"}
+    doc = {
+        "title": "Blue Jay",
+        "page_type": "birds",
+        "documentation": "This is a bird that is blue",
+        "references": [],
+    }
+
+    post_resp = splash_client.post(
+        url,
+        json=copy.deepcopy(doc),
+        headers=token_header,
+    )
+    assert post_resp.status_code == 200
+    patch_resp = splash_client.patch(
+        url + "/" + post_resp.json()["uid"], json=restore_req, headers=token_header
+    )
+    assert patch_resp.status_code == 409, f'response is {patch_resp.json()}'
+    assert patch_resp.json()["err"] == "not_archived"
+    get_resp = splash_client.get(
+        url + "/archived",
+        headers=token_header,
+    )
+    assert len(get_resp.json()) == 0
+
+    patch_resp = splash_client.patch(
+        url + "/" + post_resp.json()["uid"], json=archive_req, headers=token_header
+    )
+    assert patch_resp.status_code == 200
+    patch_resp = splash_client.patch(
+        url + "/" + post_resp.json()["uid"], json=archive_req, headers=token_header
+    )
+    assert patch_resp.status_code == 409
+    assert patch_resp.json()["err"] == "already_archived"
+    get_resp = splash_client.get(
+        url + "/archived",
+        headers=token_header,
+    )
+    assert len(get_resp.json()) == 1
 
 
 new_page = {
@@ -306,4 +426,3 @@ empty_string_title = {
                     removal and reduce fouling during nanofiltration/reverse osmosis",
     "references": [],
 }
-

--- a/splash/test/test_references_api.py
+++ b/splash/test/test_references_api.py
@@ -160,7 +160,7 @@ def test_etag_functionality(
 
 def test_retrieve_by_DOI(api_url_root, splash_client, token_header):
     url_path = api_url_root + "/references"
-    post_resp1 = create_resource(api_url_root,splash_client, token_header, reference_5)
+    post_resp1 = create_resource(api_url_root, splash_client, token_header, reference_5)
     assert (
         post_resp1.status_code == 200
     ), f"{post_resp1.status_code}: response is {post_resp1.content}"
@@ -185,6 +185,28 @@ def test_retrieve_by_DOI(api_url_root, splash_client, token_header):
     assert any(post_resp2.json()['uid'] == page['uid'] for page in get_resp2.json())
     assert any(post_resp1.json()['uid'] == page['uid'] for page in get_resp2.json())
     assert len(get_resp2.json()) == 2
+
+@pytest.mark.skip(reason="mongomock does not do case insensitive collation yet")
+def test_case_insensitivity(api_url_root, splash_client, token_header):
+    url_path = api_url_root + "/references"
+    post_resp1 = create_resource(api_url_root, splash_client, token_header, reference_8)
+    assert (
+        post_resp1.status_code == 200
+    ), f"{post_resp1.status_code}: response is {post_resp1.content}"
+
+    post_resp2 = create_resource(api_url_root, splash_client, token_header, reference_9)
+    assert (
+        post_resp2.status_code == 200
+    ), f"{post_resp2.status_code}: response is {post_resp2.content}"
+
+    get_resp = splash_client.get(
+        url_path + "/doi/" + reference_8["DOI"], headers=token_header
+    )
+    assert get_resp.status_code == 200
+    assert len(get_resp.json()) == 2
+    
+    assert any(equal_dicts(reference_8, page, ignore_keys=["uid", "splash_md"], return_value=True) for page in get_resp.json())
+    assert any(equal_dicts(reference_9, page, ignore_keys=["uid", "splash_md"], return_value=True) for page in get_resp.json())
 
 
 reference_1 = {
@@ -252,4 +274,14 @@ reference_7 = {
         {"family": "Baggins", "given": "Bilbo"},
     ],
     "origin_url": "https://data.crossref.org/10.5406/jfilmvideo.67.3-4.0079",
+}
+
+reference_8 = {
+    "DOI": "10.rrr/rrr",
+    "title": "Test8",
+}
+
+reference_9 = {
+    "title": "Test9",
+    "DOI": "10.RRR/RRR"
 }

--- a/splash/test/test_users_service.py
+++ b/splash/test/test_users_service.py
@@ -1,0 +1,122 @@
+import pytest
+from splash.users.users_service import UsersService
+from splash.service.authorization import NotAuthorized
+from splash.users import User, NewUser
+from mongomock import MongoClient
+from .testing_utils import equal_dicts
+
+
+@pytest.fixture
+def admin_user():
+    return User(
+        splash_md={
+            "creator": "NONE",
+            "create_date": "2020-01-7T13:40:53",
+            "last_edit": "2020-01-7T13:40:53",
+            "edit_record": [],
+            "etag": "f672367e-c534-4f4a-9e5a-0941dbab2d1c",
+            "admin": True
+        },
+        uid="foobar1",
+        given_name="Sauron",
+        family_name="The Dark Lord",
+        email="Sauron@mordor.net",
+    )
+
+
+@pytest.fixture
+def regular_user():
+    return User(
+        splash_md={
+            "creator": "NONE",
+            "create_date": "2020-01-7T13:40:53",
+            "last_edit": "2020-01-7T13:40:53",
+            "edit_record": [],
+            "etag": "f672367e-c534-4f4a-9e5a-0941dbab2d1c",
+            "admin": False
+        },
+        uid="foobar2",
+        given_name="Saruman",
+        family_name="The White",
+        email="saruman@middleearth.org",
+    )
+
+@pytest.fixture
+def regular_user_no_admin_prop():
+    return User(
+        splash_md={
+            "creator": "NONE",
+            "create_date": "2020-01-7T13:40:53",
+            "last_edit": "2020-01-7T13:40:53",
+            "edit_record": [],
+            "etag": "f672367e-c534-4f4a-9e5a-0941dbab2d1c",
+        },
+        uid="foobar3",
+        given_name="Gandalf",
+        family_name="The Grey",
+        email="Gandalf@middleearth.org",
+    )
+
+db = MongoClient().db
+
+
+@pytest.fixture
+def users_service():
+    users_service = UsersService(db, "users")
+    return users_service
+
+
+uid = ""
+
+
+def test_admin_can_create_and_edit(users_service: UsersService, admin_user):
+    uruk_user = NewUser(given_name="Uruk", family_name="Hai", email="uruk@mordor.net")
+    resp = users_service.create(admin_user, uruk_user)
+    uid = resp["uid"]
+    document = users_service.retrieve_one(admin_user, uid).dict()
+
+    uruk_dict = uruk_user.dict()
+
+    assert uruk_dict['given_name'] == document['given_name']
+    assert uruk_dict['family_name'] == document['family_name']
+    assert uruk_dict['email'] == document['email']
+
+    update = NewUser(given_name="Uruk", family_name="Hai", email="uruk@middleearth.org")
+    resp = users_service.update(admin_user, update, uid)
+    document = users_service.retrieve_one(admin_user, uid).dict()
+
+    update_dict = update.dict()
+
+    assert update_dict['given_name'] == document['given_name']
+    assert update_dict['family_name'] == document['family_name']
+    assert update_dict['email'] == document['email']
+
+    return
+
+
+def test_regular_cannot_edit(users_service: UsersService, regular_user):
+    uruk_user = NewUser(given_name="Uruk", family_name="Hai", email="uruk@mordor.net")
+    with pytest.raises(NotAuthorized, match="user is not an admin"):
+        users_service.create(regular_user, uruk_user)
+
+    with pytest.raises(NotAuthorized, match="user is not an admin"):
+        users_service.update(regular_user, uruk_user, uid)
+
+    with pytest.raises(NotAuthorized, match="user is not an admin"):
+        users_service.delete(regular_user, uid)
+
+    return
+
+
+def test_regular_no_admin_prop_cannot_edit(users_service: UsersService, regular_user_no_admin_prop):
+    uruk_user = NewUser(given_name="Uruk", family_name="Hai", email="uruk@mordor.net")
+    with pytest.raises(NotAuthorized, match="user is not an admin"):
+        users_service.create(regular_user_no_admin_prop, uruk_user)
+
+    with pytest.raises(NotAuthorized, match="user is not an admin"):
+        users_service.update(regular_user_no_admin_prop, uruk_user, uid)
+
+    with pytest.raises(NotAuthorized, match="user is not an admin"):
+        users_service.delete(regular_user_no_admin_prop, uid)
+
+    return

--- a/splash/test/test_versioned_service.py
+++ b/splash/test/test_versioned_service.py
@@ -48,13 +48,14 @@ def test_versioned_update(versioned_service: VersionedMongoService, request_user
         )
 
     response = versioned_service.create(
-        request_user, {"name": "Celebrimbor", "Occupation": "Ringmaker"}
+        request_user, {"splash_md": {"test": "test"}, "name": "Celebrimbor", "Occupation": "Ringmaker"}
     )
     uid = response["uid"]
 
     document_1 = versioned_service.retrieve_one(request_user, uid)
     assert document_1["uid"] == uid
     assert document_1["splash_md"]["version"] == 1
+    assert document_1["splash_md"]["test"] == "test"
     assert document_1["name"] == "Celebrimbor"
     assert document_1["Occupation"] == "Ringmaker"
     assert document_1["splash_md"] == response["splash_md"]

--- a/splash/test/testing_utils.py
+++ b/splash/test/testing_utils.py
@@ -109,6 +109,8 @@ def generic_test_etag_functionality(
     get_resp3 = splash_client.get(url_path + "/" + uid, headers=token_header)
     # Make sure that the document was not changed
     assert get_resp3.json() == get_resp2.json()
+    assert put_resp2.json()['splash_md'] == get_resp3.json()['splash_md'], f'{put_resp2.json()["splash_md"]} is not {get_resp3.json()["splash_md"]}'
+
 
 
 

--- a/splash/test/testing_utils.py
+++ b/splash/test/testing_utils.py
@@ -50,7 +50,7 @@ def generic_test_api_crud(sample_new_object, url_path, splash_client, token_head
         response.status_code == 200
     ), f"{response.status_code}: response is {response.content}"
 
-    assert post_resp.json()["splash_md"] == response.json()["splash_md"]
+    assert post_resp.json()["splash_md"] == response.json()["splash_md"], f'{post_resp.json()["splash_md"]} is not {response.json()["splash_md"]}'
     # TODO: TEST put api
 
     # response = splash_client.put(url_path + '/' + new_uid, data=json.dumps(sample_new_object), headers=token_header)

--- a/splash/test/testing_utils.py
+++ b/splash/test/testing_utils.py
@@ -73,6 +73,7 @@ def generic_test_etag_functionality(
         post_resp.status_code == 200
     ), f"{post_resp.status_code}: response is {post_resp.content}"
     assert len(post_resp.json()["splash_md"]["etag"]) > 0
+    post_resp.json()["splash_md"]["etag"] is str
     uid = post_resp.json()["uid"]
 
     get_resp1 = splash_client.get(url_path + "/" + uid, headers=token_header)

--- a/splash/test/testing_utils.py
+++ b/splash/test/testing_utils.py
@@ -112,11 +112,12 @@ def generic_test_etag_functionality(
     assert put_resp2.json()['splash_md'] == get_resp3.json()['splash_md'], f'{put_resp2.json()["splash_md"]} is not {get_resp3.json()["splash_md"]}'
 
 
-
-
 # Utility function for asserting that dicts are equal, excluding specific keys
 # https://stackoverflow.com/questions/10480806/compare-dictionaries-ignoring-specific-keys
-def equal_dicts(d1, d2, ignore_keys=[]):
+def equal_dicts(d1, d2, ignore_keys=[], return_value=False):
     d1_filtered = {k: v for k, v in d1.items() if k not in ignore_keys}
     d2_filtered = {k: v for k, v in d2.items() if k not in ignore_keys}
-    assert d1_filtered == d2_filtered, f"{d1_filtered} does not equal {d2_filtered}"
+    if return_value is False:
+        assert d1_filtered == d2_filtered, f"{d1_filtered} does not equal {d2_filtered}"
+        return
+    return d1_filtered == d2_filtered

--- a/splash/users/__init__.py
+++ b/splash/users/__init__.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 from pydantic import BaseModel, Extra
-from splash.service.models import CreatedDocument
+from splash.service.models import CreatedDocument, SplashMetadata
 
 
 class AuthenticatorModel(BaseModel):
@@ -10,8 +10,15 @@ class AuthenticatorModel(BaseModel):
     subject: Optional[str] #TODO this should be required, but data needs migration
 
 
-class NewUser(BaseModel):
+class NewUserSplashMd(BaseModel):
+    admin: Optional[bool] = None
 
+    class Config:
+        extra = Extra.forbid
+
+
+class NewUser(BaseModel):
+    splash_md: Optional[NewUserSplashMd] = NewUserSplashMd()
     given_name: str
     family_name: str
     email: Optional[str]
@@ -21,5 +28,10 @@ class NewUser(BaseModel):
         extra = Extra.forbid
 
 
+class UserSplashMd(SplashMetadata):
+    admin: Optional[bool] = None
+
+
 class User(NewUser, CreatedDocument):
     disabled: Optional[bool] = None
+    splash_md: UserSplashMd

--- a/splash/users/users_routes.py
+++ b/splash/users/users_routes.py
@@ -1,5 +1,4 @@
 from fastapi.param_functions import Header
-from splash.service.models import SplashMetadata
 from attr import dataclass
 from fastapi import APIRouter, Security
 from fastapi.exceptions import HTTPException
@@ -7,7 +6,7 @@ from fastapi.exceptions import HTTPException
 from pydantic import BaseModel
 from typing import List, Optional
 
-from . import User, NewUser
+from . import User, NewUser, UserSplashMd
 from .users_service import UsersService
 
 from splash.api.auth import get_current_user
@@ -29,7 +28,7 @@ def set_users_service(users_service: UsersService):
 
 class CreateUserResponse(BaseModel):
     uid: str
-    splash_md: SplashMetadata
+    splash_md: UserSplashMd
 
 
 @users_router.get("", tags=["users"], response_model=List[User])

--- a/splash/users/users_service.py
+++ b/splash/users/users_service.py
@@ -2,6 +2,7 @@ from pymongo import ASCENDING, DESCENDING, TEXT
 from pymongo.operations import IndexModel
 from ..users import NewUser, User
 from ..service.base import MongoService
+from ..service.authorization import authorize_admin_action
 
 
 class MultipleUsersAuthenticatorException(Exception):
@@ -24,7 +25,8 @@ class UsersService(MongoService):
         self._collection.create_indexes([text_index, sort_index])
         super()._create_indexes()
 
-    def create(self, current_user: User, new_user: NewUser) -> str:
+    @authorize_admin_action
+    def create(self, current_user: User, new_user: NewUser) -> dict:
         return super().create(current_user, new_user.dict())
 
     def retrieve_one(self, current_user: User, uid: str) -> User:
@@ -45,9 +47,11 @@ class UsersService(MongoService):
         for user_dict in cursor:
             yield User(**user_dict)
 
+    @authorize_admin_action
     def update(self, current_user: User, new_user: NewUser, uid: str, etag: str = None):
         return super().update(current_user, new_user.dict(), uid, etag=etag)
 
+    @authorize_admin_action
     def delete(self, current_user: User, uid):
         raise NotImplementedError
 


### PR DESCRIPTION
This accomodates custom references coming from the front end. For example `DOI` is no longer a unique field. `DOI` is also not required. `origin_url` is no longer required as well. The doi endpoint now returns multiple references. We also refer to references by their uid in the database and not their uid for the `references` key in a page. It also makes retrieving by the doi case insensitive.
fixes #107 

Make sure to run the migration script with this.